### PR TITLE
Add diff-api-snapshot action to danger 

### DIFF
--- a/.github/actions/diff-js-api-breaking-changes/action.yml
+++ b/.github/actions/diff-js-api-breaking-changes/action.yml
@@ -1,0 +1,21 @@
+name: diff-js-api-breaking-changes
+description: Check for breaking changes in the public React Native JS API=
+runs:
+  using: composite
+  env:
+    SCRATCH_DIR: ${{ runner.temp }}/diff-js-api-breaking-changes
+  steps:
+    - name: Fetch snapshot from PR head
+      shell: bash
+      run: |
+        mkdir $SCRATCH_DIR
+        git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
+        git show ${{ github.event.pull_request.head.sha }}:packages/react-native/ReactNativeApi.d.ts > $SCRATCH_DIR/ReactNativeApi-after.d.ts \
+          || echo "" > $SCRATCH_DIR/ReactNativeApi.d.ts
+    - name: Run breaking change detection
+      shell: bash
+      run: |
+        node ./scripts/diff-api-snapshot \
+        ${{ github.workspace }}/packages/react-native/ReactNativeApi.d.ts  \
+        $SCRATCH_DIR/ReactNativeApi-after.d.ts \
+        > $SCRATCH_DIR/output.json

--- a/.github/workflows/danger-pr.yml
+++ b/.github/workflows/danger-pr.yml
@@ -22,6 +22,8 @@ jobs:
         uses: ./.github/actions/setup-node
       - name: Run yarn install
         uses: ./.github/actions/yarn-install
+      - name: Run diff-js-api-breaking-changes
+        uses: ./.github/actions/diff-js-api-breaking-changes
       - name: Danger
         run: yarn danger ci --use-github-checks --failOnErrors
         working-directory: private/react-native-bots

--- a/private/react-native-bots/dangerfile.js
+++ b/private/react-native-bots/dangerfile.js
@@ -11,6 +11,8 @@
 'use strict';
 
 const {danger, fail, warn} = require('danger');
+const fs = require('fs');
+const path = require('path');
 
 const body = danger.github.pr.body?.toLowerCase() ?? '';
 
@@ -27,6 +29,25 @@ const isFromPhabricator = body_contains('differential revision:');
 
 // Provides advice if a summary section is missing, or body is too short
 const includesSummary = body_contains('## summary', 'summary:');
+
+const snapshot_output = JSON.parse(
+  fs.readFileSync(
+    path.join(
+      process.env.RUNNER_TEMP,
+      'diff-js-api-breaking-changes/output.json',
+    ),
+    'utf8',
+  ),
+);
+if (snapshot_output && snapshot_output.result !== 'NON_BREAKING') {
+  const title = ':exclamation: JavaScript API change detected';
+  const idea =
+    'This PR commits an update to ReactNativeApi.d.ts, indicating a change to React Native&#39;s public JavaScript API. ' +
+    'Please include a clear changelog message. ' +
+    'This change will be subject to extra review.\n\n' +
+    `This change was flagged as: <code>${snapshot_output.result}</code>`;
+  warn(`${title} - <i>${idea}</i>`);
+}
 
 const hasNoUsefulBody =
   !danger.github.pr.body || danger.github.pr.body.length < 50;


### PR DESCRIPTION
Summary:
This is a work in progress PR that adds breaking change detection to danger.

The danger is ran on a base revision from which there is no easy access to the API snapshot from the PR. The Github action fetches the PR and stores the "current" snapshot in the temporary directory which is then used in the `diff-api-snapshot` script. It is compared to the previous snapshot from the base revision which can be easily accessed by reading from `packages/react-native/ReactNativeApi.d.ts`.


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests


Test Plan:
Tested on react-native fork with personal access token. 

 {F1979339175} 

https://github.com/coado/react-native/pull/16

Differential Revision: D76735630

Pulled By: coado

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
